### PR TITLE
AWS option for testing

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -239,8 +239,8 @@
         document.addEventListener('DOMContentLoaded', () => {
 
             // --- CONFIGURATION ---
-            // !!! TODO: Replace this with the URL of a publicly hosted Axiom node for the live website demo.
-            const AXIOM_NODE_URL = 'https://axiom-engine.duckdns.org'; // <-- Works for 1 year only!
+            // Updated to use DuckDNS domain for AWS node
+            const AXIOM_NODE_URL = 'http://axiom-engine.duckdns.org:8002'; // DuckDNS domain for AWS node
 
             // --- UI ELEMENTS ---
             const queryInput = document.getElementById('query-input');

--- a/restart_nodes.sh
+++ b/restart_nodes.sh
@@ -1,31 +1,39 @@
 #!/bin/bash
 
-# Restart Axiom nodes with shared keys enabled
+# Usage:
+#   AWS_BOOTSTRAP_IP=your.aws.ip AWS_BOOTSTRAP_PORT=5002 ./restart_nodes.sh
+# or just ./restart_nodes.sh for local-only
+
+# Stop any existing Axiom nodes
 echo "Stopping any existing Axiom nodes..."
 pkill -f "axiom_server.node" || true
 
 echo "Waiting for processes to stop..."
 sleep 2
 
+# Set AWS bootstrap info if provided, else use local
+BOOTSTRAP_IP=${AWS_BOOTSTRAP_IP:-127.0.0.1}
+BOOTSTRAP_PORT=${AWS_BOOTSTRAP_PORT:-5001}
+BOOTSTRAP_URL="http://${BOOTSTRAP_IP}:${BOOTSTRAP_PORT}"
+
 echo "Starting nodes with shared keys..."
 
-# Start bootstrap node (port 5001)
-echo "Starting bootstrap node on port 5001..."
+# Start local bootstrap node (always on 5001 for local mesh)
+echo "Starting local bootstrap node on port 5001..."
 export AXIOM_SHARED_KEYS=true
 python3 -m axiom_server.node --p2p-port 5001 --api-port 8001 &
 sleep 3
 
-# Start second node (port 5002)
-echo "Starting second node on port 5002..."
+# Start peer node, bootstrapping to AWS or local
+echo "Starting peer node on port 5002, bootstrapping to $BOOTSTRAP_URL ..."
 export AXIOM_SHARED_KEYS=true
-python3 -m axiom_server.node --p2p-port 5002 --api-port 8002 --bootstrap-peer http://127.0.0.1:5001 &
+python3 -m axiom_server.node --p2p-port 5002 --api-port 8002 --bootstrap-peer "$BOOTSTRAP_URL" &
 sleep 3
 
-# Start third node (port 5004)
-echo "Starting third node on port 5004..."
+# Start another peer node, bootstrapping to AWS or local
+echo "Starting peer node on port 5004, bootstrapping to $BOOTSTRAP_URL ..."
 export AXIOM_SHARED_KEYS=true
-python3 -m axiom_server.node --p2p-port 5004 --api-port 8004 --bootstrap-peer http://127.0.0.1:5001 &
+python3 -m axiom_server.node --p2p-port 5004 --api-port 8004 --bootstrap-peer "$BOOTSTRAP_URL" &
 sleep 3
 
-echo "All nodes started. Check the logs to see if they're using shared keys."
-echo "You should see 'Loaded shared key pair from file' or 'Saved shared key pair to ...' in the logs."
+echo "All nodes started. Check the logs to see if they're using shared keys and correct bootstrap."


### PR DESCRIPTION
local setup is unchanged
only adding a AWS public bootstrap node in restart_nodes.sh and updated docs/index.html and testing global peer node sync